### PR TITLE
3 handlerfiles   organizar e estruturar chamadas

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -34,6 +34,8 @@ public class Program
             if (!Path.Exists(todayPath)) { Directory.CreateDirectory(todayPath); }
             if (!Path.Exists(todayPath)) { return; }
             if (dataBackupConfig.DestinationRoot[i].SourcePath == null) { return; }
+            var sourceFiles = new System.IO.DirectoryInfo(dataBackupConfig.DestinationRoot[i].SourcePath).GetFiles();
+            if (sourceFiles.Length == 0) { return; }
 
             for (global::System.Int32 j = 0; j < dataBackupConfig?.DestinationRoot[i]?.FileFormats?.Count; j++)
             {

--- a/Program.cs
+++ b/Program.cs
@@ -77,7 +77,5 @@ public class Program
             }
             File.Move(sourceFile.FullName, Path.Combine(destinationFolder, sourceFile.Name));
         }
-        File.Move(fileInfos.Name, Path.Combine(pathWithExtension, fileInfos.Name));
-        return null;
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -41,6 +41,12 @@ public class Program
             {
                 try
                 {
+                    if (dataBackupConfig.DestinationRoot[i].IndividualTargetFormats)
+                    {
+                        ProcessFileByFormat(file, todayPath, dataBackupConfig.DestinationRoot[i]);
+                    } else 
+                    {
+                        SafeFileMove(file, todayPath);
             }
         }
                 catch (Exception ex)

--- a/Program.cs
+++ b/Program.cs
@@ -51,8 +51,6 @@ public class Program
         }
                 catch (Exception ex)
     {
-        var originsFiles = new System.IO.DirectoryInfo(directoryBackup.SourcePath).GetFiles(fileFormat);
-        if (originsFiles.Length == 0) { return; }
 
                     throw;
                 }

--- a/Program.cs
+++ b/Program.cs
@@ -65,13 +65,17 @@ public class Program
             }
         File.Move(fileInfos.Name, Path.Combine(todayPath, fileInfos.Name));
         }
-    }
-    private static object Mover(FileInfo fileInfos, string todayPath, string extension)
+    private static void ProcessFileByFormat(FileInfo sourceFile, string todayPath, DirectoryBackup directoryBackup)
     {
-        var pathWithExtension = Path.Combine(todayPath, extension);
-        if (!Directory.Exists(pathWithExtension))
+        for (int i = 0; i < directoryBackup?.FileFormats?.Count; i++) {
+            if (sourceFile.Extension != directoryBackup.FileFormats[i]) { continue; }
+
+            var destinationFolder = Path.Combine(todayPath, directoryBackup.DestinationFolder);
+            if (!Directory.Exists(destinationFolder))
         {
-            Directory.CreateDirectory(pathWithExtension);
+                Directory.CreateDirectory(destinationFolder);
+            }
+            File.Move(sourceFile.FullName, Path.Combine(destinationFolder, sourceFile.Name));
         }
         File.Move(fileInfos.Name, Path.Combine(pathWithExtension, fileInfos.Name));
         return null;

--- a/Program.cs
+++ b/Program.cs
@@ -37,19 +37,20 @@ public class Program
             var sourceFiles = new System.IO.DirectoryInfo(dataBackupConfig.DestinationRoot[i].SourcePath).GetFiles();
             if (sourceFiles.Length == 0) { return; }
 
-            for (global::System.Int32 j = 0; j < dataBackupConfig?.DestinationRoot[i]?.FileFormats?.Count; j++)
+            Parallel.ForEach(sourceFiles, file =>
             {
-                HandlerFiles(dataBackupConfig.DestinationRoot[i], todayPath, dataBackupConfig.DestinationRoot[i].FileFormats[j]);
+                try
+                {
             }
         }
-    }
-
-    private static void HandlerFiles(DirectoryBackup directoryBackup, string todayPath, string fileFormat)
+                catch (Exception ex)
     {
         var originsFiles = new System.IO.DirectoryInfo(directoryBackup.SourcePath).GetFiles(fileFormat);
         if (originsFiles.Length == 0) { return; }
 
-        for (int i = 0; i < originsFiles.Length; i++)
+                    throw;
+                }
+            });
         {
             if (directoryBackup.IndividualTargetFormats)
             {

--- a/Program.cs
+++ b/Program.cs
@@ -17,17 +17,23 @@ public class Program
         string jsonString = File.ReadAllText(backupConfig);
         var jsonOptions = GetJsonOptions();
         var dataBackupConfig = JsonSerializer.Deserialize<BackupConfig>(jsonString, jsonOptions)!;
+        if (dataBackupConfig == null) throw new ArgumentException(nameof(DirectoryBackup));
 
         if (dataBackupConfig?.DestinationRoot?.Count <= 0 || dataBackupConfig?.DestinationRoot?.Count <= 0) { return; }
         var today = DateTime.Today;
-        string todayPath = Path.Combine(dataBackupConfig?.DirectoriesToBackup, today.ToString("dd.MM.yyyy"));
+        if (dataBackupConfig?.DirectoriesToBackup == null)
+        {
+            throw new InvalidOperationException("O caminho de backup não está configurado.");
+        }
+        string todayPath = Path.Combine(dataBackupConfig.DirectoriesToBackup, today.ToString("dd.MM.yyyy"));
 
         for (int i = 0; i < dataBackupConfig?.DestinationRoot?.Count; i++)
         {
             if (!Path.Exists(dataBackupConfig.DestinationRoot[i].SourcePath) &&
-                !Path.Exists(Path.Combine(dataBackupConfig.DirectoriesToBackup, dataBackupConfig?.DestinationRoot[i]?.DestinationFolder))) { return; }
+                !Path.Exists(Path.Combine(dataBackupConfig.DirectoriesToBackup, dataBackupConfig.DestinationRoot[i].DestinationFolder))) { return; }
             if (!Path.Exists(todayPath)) { Directory.CreateDirectory(todayPath); }
             if (!Path.Exists(todayPath)) { return; }
+            if (dataBackupConfig.DestinationRoot[i].SourcePath == null) { return; }
 
             for (global::System.Int32 j = 0; j < dataBackupConfig?.DestinationRoot[i]?.FileFormats?.Count; j++)
             {

--- a/Program.cs
+++ b/Program.cs
@@ -55,21 +55,15 @@ public class Program
                     throw;
                 }
             });
+        }
+    }
+    private static void SafeFileMove(FileInfo fileInfos, string todayPath)
         {
-            if (directoryBackup.IndividualTargetFormats)
+        if (!Directory.Exists(todayPath))
             {
-                _ = fileFormat switch
-                {
-                    ".mp4" => Mover(originsFiles[i], todayPath, originsFiles[i].Extension),
-                    ".mp3" => Mover(originsFiles[i], todayPath, originsFiles[i].Extension),
-                    ".m4a" => Mover(originsFiles[i], todayPath, originsFiles[i].Extension),
-                    ".jpg" => Mover(originsFiles[i], todayPath, originsFiles[i].Extension),
-                    _ => "",
-                };
-            } else
-            {
-                File.Move(originsFiles[i].FullName, Path.Combine(todayPath, originsFiles[i].Name));
+            Directory.CreateDirectory(todayPath);
             }
+        File.Move(fileInfos.Name, Path.Combine(todayPath, fileInfos.Name));
         }
     }
     private static object Mover(FileInfo fileInfos, string todayPath, string extension)

--- a/origins.json
+++ b/origins.json
@@ -1,27 +1,29 @@
 {
-	"DirectoriesToBackup": "C:\\backup\\",
+	"DirectoriesToBackup": "C:\\dev\\diretorio\\processado",
 	"DestinationRoot": [
+		{
+			"SourcePath": "\\storage\\emulated\\0\\Android\\media\\com.whatsapp\\WhatsApp\\Media\\WhatsApp Video",
+			"DestinationFolder": "WhatsApp Video",
+			"IndividualTargetFormats": false,
+			"FileFormats": []
+		},
 		{
 			"SourcePath": "\\storage\\emulated\\0\\Android\\media\\com.whatsapp\\WhatsApp\\Media\\WhatsApp Images",
 			"DestinationFolder": "WhatsApp Images",
 			"IndividualTargetFormats": false,
-			"FileFormats": [
-				".jpg",
-				"png",
-				".gif"
-			]
-		},
-		{
-			"SourcePath": "\\storage\\emulated\\0\\Android\\media\\com.whatsapp\\WhatsApp\\Media\\WhatsApp Video",
-			"DestinationFolder": "C:\\dev\\diretorio\\processado",
-			"IndividualTargetFormats": false,
-			"FileFormats": [ ".mp4" ]
+			"FileFormats": []
 		},
 		{
 			"SourcePath": "\\storage\\emulated\\0\\DCIM\\Camera",
-			"DestinationFolder": "C:\\dev\\diretorio\\processado",
-			"IndividualTargetFormats": false,
-			"FileFormats": [ ".mp4", ".jpg" ]
+			"DestinationFolder": "Camera Videos",
+			"IndividualTargetFormats": true,
+			"FileFormats": [ ".mp4" ]
+		},
+		{
+			"SourcePath": "\\storage\\emulated\\0\\Android\\media\\com.whatsapp\\WhatsApp\\Media\\WhatsApp Images",
+			"DestinationFolder": "Camera Fotos",
+			"IndividualTargetFormats": true,
+			"FileFormats": [ ".jpg" ]
 		}
 	]
 }


### PR DESCRIPTION
- [x] Organizar e Estruturar chamadas.
- [x] Validar objetos nulos.
- [x] Substituir HandlerFiles por `Parallel.ForEach`.
- [x] Atualizar referencia de arquivo `origins.json`. 